### PR TITLE
UI update fixes

### DIFF
--- a/BlamLib/BlamLib.Test/Halo2/Extraction.cs
+++ b/BlamLib/BlamLib.Test/Halo2/Extraction.cs
@@ -324,9 +324,9 @@ namespace BlamLib.Test
 			}
 
 			Program.Halo2.LoadPc(
-                MapsDir + @"mainmenu.map",
-                MapsDir + @"shared.map",
-                MapsDir + @"single_player_shared.map");
+				MapsDir + @"mainmenu.map",
+				MapsDir + @"shared.map",
+				MapsDir + @"single_player_shared.map");
 			Assert.IsNotNull(Program.Halo2.PcMainmenu);
 			Assert.IsNotNull(Program.Halo2.PcShared);
 			Assert.IsNotNull(Program.Halo2.PcCampaign);

--- a/BlamLib/BlamLib.Test/Halo2/Extraction.cs
+++ b/BlamLib/BlamLib.Test/Halo2/Extraction.cs
@@ -324,9 +324,9 @@ namespace BlamLib.Test
 			}
 
 			Program.Halo2.LoadPc(
-				kMapsDirectoryPc + @"mainmenu.map",
-				kMapsDirectoryPc + @"shared.map",
-				kMapsDirectoryPc + @"single_player_shared.map");
+                MapsDir + @"mainmenu.map",
+                MapsDir + @"shared.map",
+                MapsDir + @"single_player_shared.map");
 			Assert.IsNotNull(Program.Halo2.PcMainmenu);
 			Assert.IsNotNull(Program.Halo2.PcShared);
 			Assert.IsNotNull(Program.Halo2.PcCampaign);

--- a/BlamLib/BlamLib.Test/_Paths.cs
+++ b/BlamLib/BlamLib.Test/_Paths.cs
@@ -9,7 +9,7 @@ namespace BlamLib.Test
 
 	partial class TestLibrary
 	{
-		public const string kTestResultsPath = @"C:\Mount\B\Projects\test_results\";
+		public const string kTestResultsPath = @"";
 
 		public const string kProgramFilesPath =
 			@"C:\Program Files (x86)\"

--- a/Map_Handler/MainBox.cs
+++ b/Map_Handler/MainBox.cs
@@ -617,7 +617,7 @@ namespace Map_Handler
 
 
             List<int> extract_list = ExtractList.Keys.ToList<int>();
-            MainBox.H2Test.Halo2_ExtractTagCache(extract_list, isRecursive, isOutDBOn, isOverrideOn, DestinationFolder, H2V_BaseMapsDirectory + "\\", mapName);
+            MainBox.H2Test.Halo2_ExtractTagCache(extract_list, isRecursive, isOutDBOn, isOverrideOn, DestinationFolder, map_path + "\\", mapName);
             /*
             progressBar1.Value = 0;
             progressBar1.Maximum = ExtractList.Count;


### PR DESCRIPTION
Should fix loading maps that aren't in the default install location and should allow extracting maps that aren't in the same folder as the resource map folders. Also should make import info dump the files in the map handler root folder again.