### PR TITLE
[Tags] Undo a few post processing related values and blocks

### DIFF
--- a/BlamLib/BlamLib/Blam/Halo2/Tags/Code/Models.cs
+++ b/BlamLib/BlamLib/Blam/Halo2/Tags/Code/Models.cs
@@ -447,6 +447,17 @@ namespace BlamLib.Blam.Halo2.Tags
 		};
 		#endregion
 
+		#region havok shape base block
+		partial class havok_shape_base_block
+		{
+			internal override bool Reconstruct(BlamLib.Blam.CacheFile c)
+			{
+				Phantom.Value = -1;
+				return true;
+			}
+		};
+		#endregion
+
 		void ReconstructRigidBodyShapeData()
 		{
 			foreach (var rb in RigidBodies)
@@ -458,6 +469,7 @@ namespace BlamLib.Blam.Halo2.Tags
 			//ReconstructRigidBodyShapeData();
 			int Object_Count = Spheres.Count + MultiSpheres.Count + Pills.Count + Boxes.Count + Triangles.Count + Polyhedra.Count;
 			MassDistributions.Resize(Object_Count);//TODO: Find a proper way to generate values for this. This fix will only go so far.
+			Phantoms.DeleteAll();
 
 			return true;
 		}

--- a/BlamLib/BlamLib/Blam/Halo2/Tags/Code/Objects.cs
+++ b/BlamLib/BlamLib/Blam/Halo2/Tags/Code/Objects.cs
@@ -56,6 +56,10 @@ namespace BlamLib.Blam.Halo2.Tags
 		#region Reconstruct
 		internal override bool Reconstruct(BlamLib.Blam.CacheFile c)
 		{
+			if (gravity_scale.Value == 0)
+			{
+				gravity_scale.Value = 0.001f;
+			}
 			shape_phantom_shape.DeleteAll();
 			return true;
 		}

--- a/BlamLib/BlamLib/Blam/Halo2/Tags/Code/Objects.cs
+++ b/BlamLib/BlamLib/Blam/Halo2/Tags/Code/Objects.cs
@@ -56,6 +56,10 @@ namespace BlamLib.Blam.Halo2.Tags
 		#region Reconstruct
 		internal override bool Reconstruct(BlamLib.Blam.CacheFile c)
 		{
+			/*
+				If gravity scale is set to 0 then it is turned into a 1 on package.
+				0.001 should turn into a 0 on package instead of a 1
+			*/
 			if (gravity_scale.Value == 0)
 			{
 				gravity_scale.Value = 0.001f;

--- a/BlamLib/BlamLib/Blam/Halo2/Tags/Code/Resources.cs
+++ b/BlamLib/BlamLib/Blam/Halo2/Tags/Code/Resources.cs
@@ -23,6 +23,7 @@ namespace BlamLib.Blam.Halo2.Tags
 			internal override bool Reconstruct(BlamLib.Blam.CacheFile c)
 			{
 				LowDetailMipmapCount.Value = 0;
+				Flags.Value &= 0xf;
 				return true;
 			}
 

--- a/BlamLib/BlamLib/Blam/Halo2/Tags/Code/Resources.cs
+++ b/BlamLib/BlamLib/Blam/Halo2/Tags/Code/Resources.cs
@@ -23,7 +23,8 @@ namespace BlamLib.Blam.Halo2.Tags
 			internal override bool Reconstruct(BlamLib.Blam.CacheFile c)
 			{
 				LowDetailMipmapCount.Value = 0;
-				Flags.Value &= 0xf;
+				// remove extra flags that will make the HEK think the tag is invalid
+				Flags.Value &= 0xff;
 				return true;
 			}
 

--- a/BlamLib/BlamLib/Blam/Halo2/Tags/Models.cs
+++ b/BlamLib/BlamLib/Blam/Halo2/Tags/Models.cs
@@ -1454,7 +1454,7 @@ namespace BlamLib.Blam.Halo2.Tags
 
 		// I made this up. Up this made I. Not a real definition.
 		#region havok_shape_base_block
-		public abstract class havok_shape_base_block : TI.Definition
+		public partial class havok_shape_base_block : TI.Definition
 		{
 			public TI.StringId Name;
 			public TI.BlockIndex Material;

--- a/BlamLib/BlamLib/Blam/Halo2/Tags/Objects.cs
+++ b/BlamLib/BlamLib/Blam/Halo2/Tags/Objects.cs
@@ -2130,6 +2130,7 @@ namespace BlamLib.Blam.Halo2.Tags
 		#endregion
 
 		#region Fields
+		public TI.Real gravity_scale;
 		public TI.Block<vehicle_phantom_shape_block> shape_phantom_shape;
 		#endregion
 
@@ -2146,7 +2147,7 @@ namespace BlamLib.Blam.Halo2.Tags
 			Add(new TI.Pad(16));
 			Add(/*anti_gravity_bank_lift = */ new TI.Real());
 			Add(/*steering_bank_reaction_scale = */ new TI.Real());
-			Add(/*gravity scale = */ new TI.Real());
+			Add(gravity_scale = new TI.Real());
 			Add(/*radius = */ new TI.Real());
 			Add(/*anti gravity points = */ new TI.Block<anti_gravity_point_definition_block>(this, 16));
 			Add(/*friction points = */ new TI.Block<friction_point_definition_block>(this, 16));


### PR DESCRIPTION
Vehicle
If gravity scale is set to 0 then it is turned into a 1 on package. This sets gravity scale on extracted vehicles to 0.001 which should turn into a 0 on package instead of a 1

Bitmap
Cleared a byte in the bitmap flags. Should hopefully let bitmaps work out of the box.

Physics Models
Deletes the phantom tag block. This block is only created on package.

Sets phantom enum in physics mesh tag blocks to none. This is set by the referenced phantom mesh in the material on package.