### PR TITLE
[UI] Make extraction run on a new thread and some misc changes

### DIFF
--- a/BlamLib/BlamLib.Test/Halo2/Extraction.cs
+++ b/BlamLib/BlamLib.Test/Halo2/Extraction.cs
@@ -14,12 +14,12 @@ namespace BlamLib.Test
 {
 	partial class Halo2
 	{
-        public static string LTMPPath;
-        public static string SBSPPath;
-        public static string MODEPath;
+		public static string LTMPPath;
+		public static string SBSPPath;
+		public static string MODEPath;
 
-        #region ImportInfoExtraction
-        static void ExtractImportInfo(Blam.Halo2.Tags.global_tag_import_info_block tii, string out_path)
+		#region ImportInfoExtraction
+		static void ExtractImportInfo(Blam.Halo2.Tags.global_tag_import_info_block tii, string out_path)
 		{
 			if (tii != null) foreach (var b in tii.Files)
 			{
@@ -331,11 +331,11 @@ namespace BlamLib.Test
 				MapsDir + @"shared.map",
 				MapsDir + @"single_player_shared.map");
 
-            Assert.IsNotNull(Program.Halo2.PcMainmenu);
-            Assert.IsNotNull(Program.Halo2.PcShared);
-            Assert.IsNotNull(Program.Halo2.PcCampaign);
+			Assert.IsNotNull(Program.Halo2.PcMainmenu);
+			Assert.IsNotNull(Program.Halo2.PcShared);
+			Assert.IsNotNull(Program.Halo2.PcCampaign);
 
-            (Program.GetManager(game) as Managers.IStringIdController).StringIdCacheOpen(game);
+			(Program.GetManager(game) as Managers.IStringIdController).StringIdCacheOpen(game);
 			(Program.GetManager(game) as Managers.IVertexBufferController)
 				.VertexBufferCacheOpen(game);
 

--- a/BlamLib/BlamLib.Test/Halo2/Extraction.cs
+++ b/BlamLib/BlamLib.Test/Halo2/Extraction.cs
@@ -10,7 +10,6 @@ using System.Windows.Forms;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-
 namespace BlamLib.Test
 {
 	partial class Halo2
@@ -314,6 +313,8 @@ namespace BlamLib.Test
 
 			string MapsDir = "";
 
+			string file_name = map_names[0];
+
 			if (MapPath != "")
 			{
 				MapsDir = MapPath;
@@ -323,14 +324,26 @@ namespace BlamLib.Test
 				MapsDir = kMapsDirectoryPc;
 			}
 
+			string mainmenu = "mainmenu.map";
+			string shared = "shared.map";
+			string single_player_shared = "single_player_shared.map";
+
 			Program.Halo2.LoadPc(
 				MapsDir + @"mainmenu.map",
 				MapsDir + @"shared.map",
 				MapsDir + @"single_player_shared.map");
-			Assert.IsNotNull(Program.Halo2.PcMainmenu);
-			Assert.IsNotNull(Program.Halo2.PcShared);
-			Assert.IsNotNull(Program.Halo2.PcCampaign);
 
+			bool a = file_name == mainmenu;
+			bool b = file_name == shared;
+			bool c = file_name == single_player_shared;
+			bool result = (a == b) || (b == c);
+
+			if (result)
+			{
+				Assert.IsNotNull(Program.Halo2.PcMainmenu);
+				Assert.IsNotNull(Program.Halo2.PcShared);
+				Assert.IsNotNull(Program.Halo2.PcCampaign);
+			}
 
 			(Program.GetManager(game) as Managers.IStringIdController).StringIdCacheOpen(game);
 			(Program.GetManager(game) as Managers.IVertexBufferController)

--- a/BlamLib/BlamLib.Test/Halo2/Extraction.cs
+++ b/BlamLib/BlamLib.Test/Halo2/Extraction.cs
@@ -14,8 +14,12 @@ namespace BlamLib.Test
 {
 	partial class Halo2
 	{
-		#region ImportInfoExtraction
-		static void ExtractImportInfo(Blam.Halo2.Tags.global_tag_import_info_block tii, string out_path)
+        public static string LTMPPath;
+        public static string SBSPPath;
+        public static string MODEPath;
+
+        #region ImportInfoExtraction
+        static void ExtractImportInfo(Blam.Halo2.Tags.global_tag_import_info_block tii, string out_path)
 		{
 			if (tii != null) foreach (var b in tii.Files)
 			{
@@ -313,8 +317,6 @@ namespace BlamLib.Test
 
 			string MapsDir = "";
 
-			string file_name = map_names[0];
-
 			if (MapPath != "")
 			{
 				MapsDir = MapPath;
@@ -324,28 +326,16 @@ namespace BlamLib.Test
 				MapsDir = kMapsDirectoryPc;
 			}
 
-			string mainmenu = "mainmenu.map";
-			string shared = "shared.map";
-			string single_player_shared = "single_player_shared.map";
-
 			Program.Halo2.LoadPc(
 				MapsDir + @"mainmenu.map",
 				MapsDir + @"shared.map",
 				MapsDir + @"single_player_shared.map");
 
-			bool a = file_name == mainmenu;
-			bool b = file_name == shared;
-			bool c = file_name == single_player_shared;
-			bool result = (a == b) || (b == c);
+            Assert.IsNotNull(Program.Halo2.PcMainmenu);
+            Assert.IsNotNull(Program.Halo2.PcShared);
+            Assert.IsNotNull(Program.Halo2.PcCampaign);
 
-			if (result)
-			{
-				Assert.IsNotNull(Program.Halo2.PcMainmenu);
-				Assert.IsNotNull(Program.Halo2.PcShared);
-				Assert.IsNotNull(Program.Halo2.PcCampaign);
-			}
-
-			(Program.GetManager(game) as Managers.IStringIdController).StringIdCacheOpen(game);
+            (Program.GetManager(game) as Managers.IStringIdController).StringIdCacheOpen(game);
 			(Program.GetManager(game) as Managers.IVertexBufferController)
 				.VertexBufferCacheOpen(game);
 

--- a/BlamLib/BlamLib.Test/Halo2/Halo2.cs
+++ b/BlamLib/BlamLib.Test/Halo2/Halo2.cs
@@ -174,44 +174,18 @@ namespace BlamLib.Test
 		#region COLLADA tests
 		static readonly ModelTestDefinition[] LightmapTestDefinitions = new ModelTestDefinition[]
 		{
-			new ModelTestDefinition("LTMP", @"scenarios\multi\example\example_example_lightmap",
+			new ModelTestDefinition("LTMP", LTMPPath,
 			    Blam.Halo2.TagGroups.ltmp)
 		};
 		static readonly ModelTestDefinition[] BSPTestDefinitions = new ModelTestDefinition[]
 		{
-			new ModelTestDefinition("SBSP", @"scenarios\multi\example\example",
-			    Blam.Halo2.TagGroups.sbsp),
-			new ModelTestDefinition("SBSP", @"scenarios\solo\03a_oldmombasa\earthcity_3b",
-			    Blam.Halo2.TagGroups.sbsp),
-			new ModelTestDefinition("SBSP", @"scenarios\solo\03b_newmombasa\earthcity_4",
-			    Blam.Halo2.TagGroups.sbsp),
-			new ModelTestDefinition("SBSP", @"scenarios\solo\07a_highcharity\high_0",
-			    Blam.Halo2.TagGroups.sbsp),
-			new ModelTestDefinition("SBSP", @"scenarios\multi\backwash\backwash",
+			new ModelTestDefinition("SBSP", SBSPPath,
 			    Blam.Halo2.TagGroups.sbsp)
 		};
 		static readonly ModelTestDefinition[] RenderModelTestDefinitions = new ModelTestDefinition[]
 		{
-			new ModelTestDefinition("MODE", @"objects\characters\elite\elite",
-			    Blam.Halo2.TagGroups.mode),
-			new ModelTestDefinition("MODE", @"objects\characters\masterchief\masterchief",
-			    Blam.Halo2.TagGroups.mode),
-			new ModelTestDefinition("MODE", @"objects\vehicles\wraith\wraith",
-			    Blam.Halo2.TagGroups.mode),
-			new ModelTestDefinition("MODE", @"objects\characters\elite\fp_body\fp_body",
-			    Blam.Halo2.TagGroups.mode),
-			new ModelTestDefinition("MODE", @"scenarios\skies\multi\halo\coagulation\coagulation",
-			    Blam.Halo2.TagGroups.mode),
-			new ModelTestDefinition("MODE", @"objects\vehicles\wraith\turrets\minigun\minigun",
-			    Blam.Halo2.TagGroups.mode),
-			new ModelTestDefinition("MODE", @"objects\vehicles\warthog\warthog",
-			    Blam.Halo2.TagGroups.mode),
-			new ModelTestDefinition("MODE", @"objects\vehicles\warthog\turrets\gauss\gauss",
-			    Blam.Halo2.TagGroups.mode),
-			new ModelTestDefinition("MODE", @"objects\characters\masterchief\fp\fp",
-			    Blam.Halo2.TagGroups.mode),
-			new ModelTestDefinition("MODE", @"objects\characters\elite\fp_arms\fp_arms",
-			    Blam.Halo2.TagGroups.mode),
+			new ModelTestDefinition("MODE", MODEPath,
+			    Blam.Halo2.TagGroups.mode)
 		};
 
 		[TestMethod]

--- a/BlamLib/BlamLib.Test/Halo2/Halo2.cs
+++ b/BlamLib/BlamLib.Test/Halo2/Halo2.cs
@@ -175,17 +175,17 @@ namespace BlamLib.Test
 		static readonly ModelTestDefinition[] LightmapTestDefinitions = new ModelTestDefinition[]
 		{
 			new ModelTestDefinition("LTMP", LTMPPath,
-			    Blam.Halo2.TagGroups.ltmp)
+				Blam.Halo2.TagGroups.ltmp)
 		};
 		static readonly ModelTestDefinition[] BSPTestDefinitions = new ModelTestDefinition[]
 		{
 			new ModelTestDefinition("SBSP", SBSPPath,
-			    Blam.Halo2.TagGroups.sbsp)
+				Blam.Halo2.TagGroups.sbsp)
 		};
 		static readonly ModelTestDefinition[] RenderModelTestDefinitions = new ModelTestDefinition[]
 		{
 			new ModelTestDefinition("MODE", MODEPath,
-			    Blam.Halo2.TagGroups.mode)
+				Blam.Halo2.TagGroups.mode)
 		};
 
 		[TestMethod]

--- a/BlamLib/BlamLib.Test/Program.cs
+++ b/BlamLib/BlamLib.Test/Program.cs
@@ -88,13 +88,13 @@ namespace BlamLib.Test
 		public readonly string Directory;
 		public readonly string MapName;
 		readonly string mapPath;
-        public Blam.DatumIndex DatumIndex;
-        public bool Recursive = false;
-        public string ExtractDirectory="";
-        public bool Output_DB;
-        public bool Overrite;
+		public Blam.DatumIndex DatumIndex;
+		public bool Recursive = false;
+		public string ExtractDirectory="";
+		public bool Output_DB;
+		public bool Overrite;
 
-        public CacheFileOutputInfoArgs(TestContext tc, BlamVersion g, string d, string m)
+		public CacheFileOutputInfoArgs(TestContext tc, BlamVersion g, string d, string m)
 		{
 			TestContext = tc;
 			Game = g;
@@ -102,21 +102,21 @@ namespace BlamLib.Test
 			MapName = m;
 			mapPath = System.IO.Path.Combine(Directory, MapName);
 		}
-        public CacheFileOutputInfoArgs(TestContext tc, BlamVersion g, string d, Blam.DatumIndex D,bool R, bool DB, bool Ov,string Ex,string m)
-        {
-            TestContext = tc;
-            Game = g;
-            Directory = d;
-            MapName = m;
-            DatumIndex = D;
-            Recursive = R;
-            Output_DB = DB;
-            Overrite = Ov;
-            mapPath = System.IO.Path.Combine(Directory, MapName);
-            ExtractDirectory = Ex;
-        }
+		public CacheFileOutputInfoArgs(TestContext tc, BlamVersion g, string d, Blam.DatumIndex D,bool R, bool DB, bool Ov,string Ex,string m)
+		{
+			TestContext = tc;
+			Game = g;
+			Directory = d;
+			MapName = m;
+			DatumIndex = D;
+			Recursive = R;
+			Output_DB = DB;
+			Overrite = Ov;
+			mapPath = System.IO.Path.Combine(Directory, MapName);
+			ExtractDirectory = Ex;
+		}
 
-        public string MapPath { get { return mapPath; } }
+		public string MapPath { get { return mapPath; } }
 
 		public string TestResultsPath
 		{ get {
@@ -159,36 +159,36 @@ namespace BlamLib.Test
 
 			return args;
 		}
-        static List<CacheFileOutputInfoArgs> TestMethodBuildArgs(TestContext tc,
-         BlamVersion game, string dir, Blam.DatumIndex DatumIndex,bool Recursive, bool OutputDB, bool Overrite,string Ext_Dir , params string[] map_names)
-        {
-            var args = new List<CacheFileOutputInfoArgs>(map_names.Length);
-            for (int x = 0; x < map_names.Length; x++)
-            {
-                var arg = new CacheFileOutputInfoArgs(tc, game, dir, DatumIndex,Recursive, OutputDB,Overrite,Ext_Dir, map_names[x]);
+		static List<CacheFileOutputInfoArgs> TestMethodBuildArgs(TestContext tc,
+		 BlamVersion game, string dir, Blam.DatumIndex DatumIndex,bool Recursive, bool OutputDB, bool Overrite,string Ext_Dir , params string[] map_names)
+		{
+			var args = new List<CacheFileOutputInfoArgs>(map_names.Length);
+			for (int x = 0; x < map_names.Length; x++)
+			{
+				var arg = new CacheFileOutputInfoArgs(tc, game, dir, DatumIndex,Recursive, OutputDB,Overrite,Ext_Dir, map_names[x]);
 
-                if (arg.ValidateReadyStatus())
-                    args.Add(arg);
-            }
+				if (arg.ValidateReadyStatus())
+					args.Add(arg);
+			}
 
-            return args;
-        }
-        public static void TestMethodThreaded(TestContext tc, WaitCallback method,
+			return args;
+		}
+		public static void TestMethodThreaded(TestContext tc, WaitCallback method,
 			BlamVersion game, string dir, params string[] map_names)
 		{
 			var args = TestMethodBuildArgs(tc, game, dir, map_names);
 
 			TestLibrary.TestMethodThreaded(method, args.ToArray());
 		}
-        public static void TestThreadedMethod(TestContext tc, WaitCallback method,
-             BlamVersion game, string dir, Blam.DatumIndex Datum,bool Recursive ,bool OutputDB, bool Overrite ,string Ext_Dir, params string[] map_names)
-        {
-            var args = TestMethodBuildArgs(tc, game, dir, Datum,Recursive,OutputDB,Overrite, Ext_Dir, map_names);
+		public static void TestThreadedMethod(TestContext tc, WaitCallback method,
+			 BlamVersion game, string dir, Blam.DatumIndex Datum,bool Recursive ,bool OutputDB, bool Overrite ,string Ext_Dir, params string[] map_names)
+		{
+			var args = TestMethodBuildArgs(tc, game, dir, Datum,Recursive,OutputDB,Overrite, Ext_Dir, map_names);
 
-            TestLibrary.TestMethodThreaded(method, args.ToArray());
-        }
+			TestLibrary.TestMethodThreaded(method, args.ToArray());
+		}
 
-        public static void TestMethodSerial(TestContext tc, WaitCallback method,
+		public static void TestMethodSerial(TestContext tc, WaitCallback method,
 			BlamVersion game, string dir, params string[] map_names)
 		{
 			var args = TestMethodBuildArgs(tc, game, dir, map_names);
@@ -341,12 +341,12 @@ namespace BlamLib.Test
 		public string TypeString;
 		public string Name;
 		public TagInterface.TagGroup Group;
-        public static string Tagfile;
+		public static string Tagfile;
 
-        public ModelTestDefinition(string type, string name, TagInterface.TagGroup group)
+		public ModelTestDefinition(string type, string name, TagInterface.TagGroup group)
 		{
 			TypeString = type;
-            Tagfile = name;
+			Tagfile = name;
 			Group = group;
 		}
 

--- a/BlamLib/BlamLib.Test/Program.cs
+++ b/BlamLib/BlamLib.Test/Program.cs
@@ -336,23 +336,24 @@ namespace BlamLib.Test
 	};
 
 	/// <summary>Utility class for COLLADA nonsense</summary>
-	class ModelTestDefinition
+	public class ModelTestDefinition
 	{
 		public string TypeString;
 		public string Name;
 		public TagInterface.TagGroup Group;
+        public static string Tagfile;
 
-		public ModelTestDefinition(string type, string name, TagInterface.TagGroup group)
+        public ModelTestDefinition(string type, string name, TagInterface.TagGroup group)
 		{
 			TypeString = type;
-			Name = name;
+            Tagfile = name;
 			Group = group;
 		}
 
 		public Blam.DatumIndex TagIndex = Blam.DatumIndex.Null;
 		public void Open(Managers.TagIndex tag_index)
 		{
-			TagIndex = tag_index.Open(Name, Group, IO.ITagStreamFlags.LoadDependents);
+			TagIndex = tag_index.Open(Tagfile, Group, IO.ITagStreamFlags.LoadDependents);
 			Assert.IsFalse(TagIndex.IsNull);
 		}
 		public void Close(Managers.TagIndex tag_index)

--- a/Map_Handler/MainBox.Designer.cs
+++ b/Map_Handler/MainBox.Designer.cs
@@ -51,6 +51,13 @@
             this.getTagStructureToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resyncshadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.resyncStringIDsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sndtagFixesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.dumpTagListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.dumpStringIDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.shaderEmulatorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.createPluginsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.dumpShadersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.emulateShaderDumpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.defaultMaToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.treeView1 = new System.Windows.Forms.TreeView();
@@ -79,13 +86,9 @@
             this.button6 = new System.Windows.Forms.Button();
             this.label4 = new System.Windows.Forms.Label();
             this.clear_button = new System.Windows.Forms.Button();
-            this.sndtagFixesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.dumpTagListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.dumpStringIDToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.shaderEmulatorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.createPluginsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.dumpShadersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.emulateShaderDumpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.extractLTMPCOLLADAToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.extractSBSPCOLLADAToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.extractMODECOLLADAToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -147,9 +150,12 @@
             this.extractImportInfoToolStripMenuItem,
             this.convertToolStripMenuItem,
             this.dumpSelectedTagsListToolStripMenuItem,
-            this.tests1ToolStripMenuItem});
+            this.tests1ToolStripMenuItem,
+            this.extractLTMPCOLLADAToolStripMenuItem,
+            this.extractSBSPCOLLADAToolStripMenuItem,
+            this.extractMODECOLLADAToolStripMenuItem});
             this.testToolStripMenuItem.Name = "testToolStripMenuItem";
-            this.testToolStripMenuItem.Size = new System.Drawing.Size(41, 20);
+            this.testToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
             this.testToolStripMenuItem.Text = "Test";
             // 
             // extractImportInfoToolStripMenuItem
@@ -213,7 +219,7 @@
             this.extractTagToolStripMenuItem,
             this.decompileMapToolStripMenuItem});
             this.TagToolStripMenu.Name = "TagToolStripMenu";
-            this.TagToolStripMenu.Size = new System.Drawing.Size(39, 20);
+            this.TagToolStripMenu.Size = new System.Drawing.Size(37, 20);
             this.TagToolStripMenu.Text = "Tag";
             this.TagToolStripMenu.Visible = false;
             // 
@@ -250,37 +256,89 @@
             // extractMetaToolStripMenuItem
             // 
             this.extractMetaToolStripMenuItem.Name = "extractMetaToolStripMenuItem";
-            this.extractMetaToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.extractMetaToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
             this.extractMetaToolStripMenuItem.Text = "Extract meta";
             this.extractMetaToolStripMenuItem.Click += new System.EventHandler(this.extractMetaToolStripMenuItem_Click);
             // 
             // injectMetaToolStripMenuItem
             // 
             this.injectMetaToolStripMenuItem.Name = "injectMetaToolStripMenuItem";
-            this.injectMetaToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.injectMetaToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
             this.injectMetaToolStripMenuItem.Text = "Compile meta";
             this.injectMetaToolStripMenuItem.Click += new System.EventHandler(this.CompileMetaToolStripMenuItem_Click);
             // 
             // getTagStructureToolStripMenuItem
             // 
             this.getTagStructureToolStripMenuItem.Name = "getTagStructureToolStripMenuItem";
-            this.getTagStructureToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.getTagStructureToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
             this.getTagStructureToolStripMenuItem.Text = "Get Tag Structure";
             this.getTagStructureToolStripMenuItem.Click += new System.EventHandler(this.getTagStructureToolStripMenuItem_Click);
             // 
             // resyncshadToolStripMenuItem
             // 
             this.resyncshadToolStripMenuItem.Name = "resyncshadToolStripMenuItem";
-            this.resyncshadToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.resyncshadToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
             this.resyncshadToolStripMenuItem.Text = "Resync tagRefs";
             this.resyncshadToolStripMenuItem.Click += new System.EventHandler(this.resyncshadToolStripMenuItem_Click);
             // 
             // resyncStringIDsToolStripMenuItem
             // 
             this.resyncStringIDsToolStripMenuItem.Name = "resyncStringIDsToolStripMenuItem";
-            this.resyncStringIDsToolStripMenuItem.Size = new System.Drawing.Size(166, 22);
+            this.resyncStringIDsToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
             this.resyncStringIDsToolStripMenuItem.Text = "Resync StringIDs";
             this.resyncStringIDsToolStripMenuItem.Click += new System.EventHandler(this.resyncStringIDsToolStripMenuItem_Click);
+            // 
+            // sndtagFixesToolStripMenuItem
+            // 
+            this.sndtagFixesToolStripMenuItem.Name = "sndtagFixesToolStripMenuItem";
+            this.sndtagFixesToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
+            this.sndtagFixesToolStripMenuItem.Text = "snd!_tag Fixes";
+            this.sndtagFixesToolStripMenuItem.Click += new System.EventHandler(this.sndtagFixesToolStripMenuItem_Click);
+            // 
+            // dumpTagListToolStripMenuItem
+            // 
+            this.dumpTagListToolStripMenuItem.Name = "dumpTagListToolStripMenuItem";
+            this.dumpTagListToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
+            this.dumpTagListToolStripMenuItem.Text = "Dump tag list";
+            this.dumpTagListToolStripMenuItem.Click += new System.EventHandler(this.dumpTagListToolStripMenuItem_Click);
+            // 
+            // dumpStringIDToolStripMenuItem
+            // 
+            this.dumpStringIDToolStripMenuItem.Name = "dumpStringIDToolStripMenuItem";
+            this.dumpStringIDToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
+            this.dumpStringIDToolStripMenuItem.Text = "Dump StringID";
+            this.dumpStringIDToolStripMenuItem.Click += new System.EventHandler(this.dumpStringIDToolStripMenuItem_Click);
+            // 
+            // shaderEmulatorToolStripMenuItem
+            // 
+            this.shaderEmulatorToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.createPluginsToolStripMenuItem,
+            this.dumpShadersToolStripMenuItem,
+            this.emulateShaderDumpToolStripMenuItem});
+            this.shaderEmulatorToolStripMenuItem.Name = "shaderEmulatorToolStripMenuItem";
+            this.shaderEmulatorToolStripMenuItem.Size = new System.Drawing.Size(164, 22);
+            this.shaderEmulatorToolStripMenuItem.Text = "Shader Emulator";
+            // 
+            // createPluginsToolStripMenuItem
+            // 
+            this.createPluginsToolStripMenuItem.Name = "createPluginsToolStripMenuItem";
+            this.createPluginsToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.createPluginsToolStripMenuItem.Text = "Create Shader Plugins";
+            this.createPluginsToolStripMenuItem.Click += new System.EventHandler(this.CreatePluginsToolStripMenuItem_Click);
+            // 
+            // dumpShadersToolStripMenuItem
+            // 
+            this.dumpShadersToolStripMenuItem.Name = "dumpShadersToolStripMenuItem";
+            this.dumpShadersToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.dumpShadersToolStripMenuItem.Text = "Export Shader Dump";
+            this.dumpShadersToolStripMenuItem.Click += new System.EventHandler(this.DumpShadersToolStripMenuItem_Click);
+            // 
+            // emulateShaderDumpToolStripMenuItem
+            // 
+            this.emulateShaderDumpToolStripMenuItem.Name = "emulateShaderDumpToolStripMenuItem";
+            this.emulateShaderDumpToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
+            this.emulateShaderDumpToolStripMenuItem.Text = "Process Shader Dump";
+            this.emulateShaderDumpToolStripMenuItem.Click += new System.EventHandler(this.EmulateShaderDumpToolStripMenuItem_Click);
             // 
             // settingsToolStripMenuItem
             // 
@@ -309,44 +367,6 @@
             this.treeView1.Size = new System.Drawing.Size(406, 619);
             this.treeView1.TabIndex = 1;
             this.treeView1.AfterCheck += new System.Windows.Forms.TreeViewEventHandler(this.treeView1_AfterCheck);
-            // 
-            // sndtagFixesToolStripMenuItem
-            // 
-            this.sndtagFixesToolStripMenuItem.Name = "sndtagFixesToolStripMenuItem";
-            this.sndtagFixesToolStripMenuItem.Size = new System.Drawing.Size(197, 26);
-            this.sndtagFixesToolStripMenuItem.Text = "snd!_tag Fixes";
-            this.sndtagFixesToolStripMenuItem.Click += new System.EventHandler(this.sndtagFixesToolStripMenuItem_Click);
-            // 
-            // shaderEmulatorToolStripMenuItem
-            // 
-            this.shaderEmulatorToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.createPluginsToolStripMenuItem,
-            this.dumpShadersToolStripMenuItem,
-            this.emulateShaderDumpToolStripMenuItem});
-            this.shaderEmulatorToolStripMenuItem.Name = "shaderEmulatorToolStripMenuItem";
-            this.shaderEmulatorToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.shaderEmulatorToolStripMenuItem.Text = "Shader Emulator";
-            // 
-            // createPluginsToolStripMenuItem
-            // 
-            this.createPluginsToolStripMenuItem.Name = "createPluginsToolStripMenuItem";
-            this.createPluginsToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
-            this.createPluginsToolStripMenuItem.Text = "Create Shader Plugins";
-            this.createPluginsToolStripMenuItem.Click += new System.EventHandler(this.CreatePluginsToolStripMenuItem_Click);
-            // 
-            // dumpShadersToolStripMenuItem
-            // 
-            this.dumpShadersToolStripMenuItem.Name = "dumpShadersToolStripMenuItem";
-            this.dumpShadersToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
-            this.dumpShadersToolStripMenuItem.Text = "Export Shader Dump";
-            this.dumpShadersToolStripMenuItem.Click += new System.EventHandler(this.DumpShadersToolStripMenuItem_Click);
-            // 
-            // emulateShaderDumpToolStripMenuItem
-            // 
-            this.emulateShaderDumpToolStripMenuItem.Name = "emulateShaderDumpToolStripMenuItem";
-            this.emulateShaderDumpToolStripMenuItem.Size = new System.Drawing.Size(189, 22);
-            this.emulateShaderDumpToolStripMenuItem.Text = "Process Shader Dump";
-            this.emulateShaderDumpToolStripMenuItem.Click += new System.EventHandler(this.EmulateShaderDumpToolStripMenuItem_Click);
             // 
             // textBox1
             // 
@@ -647,19 +667,26 @@
             this.clear_button.UseVisualStyleBackColor = true;
             this.clear_button.Click += new System.EventHandler(this.clear_button_Click);
             // 
-            // dumpTagListToolStripMenuItem
+            // extractLTMPCOLLADAToolStripMenuItem
             // 
-            this.dumpTagListToolStripMenuItem.Name = "dumpTagListToolStripMenuItem";
-            this.dumpTagListToolStripMenuItem.Size = new System.Drawing.Size(197, 26);
-            this.dumpTagListToolStripMenuItem.Text = "Dump tag list";
-            this.dumpTagListToolStripMenuItem.Click += new System.EventHandler(this.dumpTagListToolStripMenuItem_Click);
+            this.extractLTMPCOLLADAToolStripMenuItem.Name = "extractLTMPCOLLADAToolStripMenuItem";
+            this.extractLTMPCOLLADAToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
+            this.extractLTMPCOLLADAToolStripMenuItem.Text = "Extract LTMP COLLADA";
+            this.extractLTMPCOLLADAToolStripMenuItem.Click += new System.EventHandler(this.extractLTMPCOLLADAToolStripMenuItem_Click);
             // 
-            // dumpStringIDToolStripMenuItem
+            // extractSBSPCOLLADAToolStripMenuItem
             // 
-            this.dumpStringIDToolStripMenuItem.Name = "dumpStringIDToolStripMenuItem";
-            this.dumpStringIDToolStripMenuItem.Size = new System.Drawing.Size(197, 26);
-            this.dumpStringIDToolStripMenuItem.Text = "Dump StringID";
-            this.dumpStringIDToolStripMenuItem.Click += new System.EventHandler(this.dumpStringIDToolStripMenuItem_Click);
+            this.extractSBSPCOLLADAToolStripMenuItem.Name = "extractSBSPCOLLADAToolStripMenuItem";
+            this.extractSBSPCOLLADAToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
+            this.extractSBSPCOLLADAToolStripMenuItem.Text = "Extract SBSP COLLADA";
+            this.extractSBSPCOLLADAToolStripMenuItem.Click += new System.EventHandler(this.extractSBSPCOLLADAToolStripMenuItem_Click);
+            // 
+            // extractMODECOLLADAToolStripMenuItem
+            // 
+            this.extractMODECOLLADAToolStripMenuItem.Name = "extractMODECOLLADAToolStripMenuItem";
+            this.extractMODECOLLADAToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
+            this.extractMODECOLLADAToolStripMenuItem.Text = "Extract MODE COLLADA";
+            this.extractMODECOLLADAToolStripMenuItem.Click += new System.EventHandler(this.extractMODECOLLADAToolStripMenuItem_Click);
             // 
             // MainBox
             // 
@@ -748,6 +775,9 @@
         private System.Windows.Forms.ToolStripMenuItem emulateShaderDumpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem dumpTagListToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem dumpStringIDToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem extractLTMPCOLLADAToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem extractSBSPCOLLADAToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem extractMODECOLLADAToolStripMenuItem;
     }
 }
 

--- a/Map_Handler/MainBox.cs
+++ b/Map_Handler/MainBox.cs
@@ -544,23 +544,17 @@ namespace Map_Handler
 
         private void extract_button_Click(object sender, EventArgs e)
         {
+            clear_button.Enabled = false;
+            extract_button.Enabled = false;
+            fileToolStripMenuItem.Enabled = false;
+            button1.Enabled = false;
+            button2.Enabled = false;
+            button3.Enabled = false;
+            button4.Enabled = false;
+            treeView1.Enabled = false;
             new Thread(() => 
             {
                 Thread.CurrentThread.IsBackground = true;
-                clear_button.Invoke(new MethodInvoker(() => clear_button.Enabled = false));
-                extract_button.Invoke(new MethodInvoker(() => extract_button.Enabled = false));
-
-                this.BeginInvoke(new MethodInvoker(delegate ()
-                {
-                    fileToolStripMenuItem.Enabled = false;
-                }
-                ));
-
-                button1.Invoke(new MethodInvoker(() => button1.Enabled = false));
-                button2.Invoke(new MethodInvoker(() => button2.Enabled = false));
-                button3.Invoke(new MethodInvoker(() => button3.Enabled = false));
-                button4.Invoke(new MethodInvoker(() => button4.Enabled = false));
-                treeView1.Invoke(new MethodInvoker(() => treeView1.Enabled = false));
                 isRecursive = recursive_radio_.Checked;
                 isOverrideOn = override_tags_.Checked;
                 isOutDBOn = output_db_.Checked;


### PR DESCRIPTION
Extraction now runs on a new thread. This means that the program no longer stops responsing and can be messed with during the process.
This has brought out some new problems such as

Attempting to load a resource map after loading a regular map file will result in a crash due the file being in use. I assume this has something to do with the asserts. This bug existed before but turned from the program refusing to load resource maps to crashing while attempting to load them.

The "selected tags" count is cleared when loading or closing a map.

Close the map_stream while loading and closing the map to avoid some  crashes.

Disable parts of the UI related to extraction during extraction to avoid some crashes.

A really trash workaround for the whole "can't extract from shared properly thing". Isn't the best thing that could probably be done but this solves the issue for now.